### PR TITLE
refactor download functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,6 @@ Config/testthat/edition: 3
 Depends: 
     R (>= 4.1.0)
 Imports: 
-    archive,
     arrow,
     dplyr,
     sf,

--- a/R/compute_lumi.R
+++ b/R/compute_lumi.R
@@ -83,8 +83,7 @@ compute_lumi <- function(
   )
   zip_path <- zip_info$zip_path
 
-  arch_info <- archive::archive(zip_path)
-  csv_inside <- .cnefe_first_csv_in_archive(arch_info)
+  csv_inside <- .cnefe_first_csv_in_zip(zip_path)
 
   log_step_time("Step 1/3 (ZIP ready)", t1)
 

--- a/R/hex_cnefe_counts.R
+++ b/R/hex_cnefe_counts.R
@@ -69,8 +69,7 @@ hex_cnefe_counts <- function(
   )
   zip_path <- zip_info$zip_path
 
-  arch_info <- archive::archive(zip_path)
-  csv_inside <- .cnefe_first_csv_in_archive(arch_info)
+  csv_inside <- .cnefe_first_csv_in_zip(zip_path)
 
   log_step_time("Step 1/3 (ZIP ready)", t1)
 

--- a/R/read_cnefe.R
+++ b/R/read_cnefe.R
@@ -77,17 +77,21 @@ read_cnefe <- function(
     add = TRUE
   )
 
-  # List archive and find first CSV inside
+  # List files and find first CSV inside
   if (verbose) {
-    message("Listing archive contents...")
+    message("Listing file contents...")
   }
-  arch_info <- archive::archive(zip_path)
-  csv_inside <- .cnefe_first_csv_in_archive(arch_info)
+  csv_inside <- .cnefe_first_csv_in_zip(zip_path)
 
   if (verbose) {
     message("Extracting ", csv_inside, " ...")
   }
-  archive::archive_extract(zip_path, file = csv_inside, dir = tmp_dir)
+
+  utils::unzip(
+    zipfile = zip_path,
+    files   = csv_inside,
+    exdir   = tmp_dir
+  )
 
   csv_path <- file.path(tmp_dir, csv_inside)
   if (!file.exists(csv_path)) {

--- a/tests/testthat/test-compute_lumi.R
+++ b/tests/testthat/test-compute_lumi.R
@@ -1,5 +1,4 @@
 testthat::test_that("compute_lumi computes expected p_res on offline fixture (backend r)", {
-  testthat::skip_if_not_installed("archive")
   testthat::skip_if_not_installed("arrow")
   testthat::skip_if_not_installed("dplyr")
   testthat::skip_if_not_installed("h3jsr")

--- a/tests/testthat/test-hex_cnefe_counts.R
+++ b/tests/testthat/test-hex_cnefe_counts.R
@@ -1,5 +1,4 @@
 testthat::test_that("hex_cnefe_counts works offline using ZIP fixture (backend r)", {
-  testthat::skip_if_not_installed("archive")
   testthat::skip_if_not_installed("arrow")
   testthat::skip_if_not_installed("dplyr")
   testthat::skip_if_not_installed("h3jsr")

--- a/tests/testthat/test-read_cnefe.R
+++ b/tests/testthat/test-read_cnefe.R
@@ -26,7 +26,6 @@ testthat::test_that(".normalize_code_muni validates inputs", {
 })
 
 testthat::test_that("read_cnefe reads from internal ZIP fixture (offline) as Arrow table", {
-  #testthat::skip_if_not_installed("archive")
   testthat::skip_if_not_installed("arrow")
 
   code_muni <- 2927408L
@@ -49,7 +48,6 @@ testthat::test_that("read_cnefe reads from internal ZIP fixture (offline) as Arr
 })
 
 testthat::test_that("read_cnefe reads from internal ZIP fixture (offline) as sf", {
-  #testthat::skip_if_not_installed("archive")
   testthat::skip_if_not_installed("arrow")
   testthat::skip_if_not_installed("sf")
 


### PR DESCRIPTION
This pull request refactors the codebase to remove the dependency on the `archive` package for handling ZIP files, replacing it with base R utilities and modern packages like `fs` and `httr2`. It updates all relevant functions to use `utils::unzip` for ZIP file operations, improves error handling and argument validation, and updates package dependencies accordingly. The changes also introduce `checkmate` for input validation and streamline download logic for robustness and clarity.

**Dependency and Imports Updates**
* Removed `archive` from `Imports:` and added `checkmate`, `fs`, and `httr2` to support new ZIP and file handling logic in `DESCRIPTION`. [[1]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL38) [[2]](diffhunk://#diff-9cc358405149db607ff830a16f0b4b21f7366e3c99ec00d52800acebe21b231cL50-R52)

**ZIP File Handling Refactor**
* Replaced all uses of `archive::archive()` with a new helper function `.cnefe_first_csv_in_zip()` that uses `utils::unzip()` to list and validate CSV files inside ZIP archives across all relevant functions (`compute_lumi`, `hex_cnefe_counts`, `read_cnefe`, and internal utilities). [[1]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L102-R103) [[2]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L632-R667) [[3]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L61-R61) [[4]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L122-R122) [[5]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L141-R252) [[6]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250R428-R521) [[7]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L492-R530) [[8]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L526-R563) [[9]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L540-R576) [[10]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L632-R667) [[11]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L102-R103) [[12]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L122-R122) [[13]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L141-R252) [[14]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250R428-R521) [[15]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L492-R530) [[16]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L526-R563) [[17]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L540-R576) [[18]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L632-R667)

**Download Logic Improvements**
* Refactored download functions to use `httr2` for HTTP requests and `fs` for file operations, adding robust error handling, retries (`retry_timeouts`), and input validation via `checkmate`. The download logic now aborts with informative errors if downloads fail or files are invalid. [[1]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L141-R252) [[2]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250R428-R521)

**Function Argument Changes**
* Changed function arguments from `base_timeout` and `timeouts` to a single `retry_timeouts` parameter for clarity and consistency in download retries. This affects all functions that download files or ZIPs. [[1]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L61-R61) [[2]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L122-R122) [[3]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L492-R530) [[4]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L526-R563) [[5]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L540-R576) [[6]](diffhunk://#diff-310412f8961af7e36c45ce4c1b6872f2630ef15d2c3ee1941b4de1d49fc497a2L60-R60) [[7]](diffhunk://#diff-aae4be437219742d357c8c4b2bca1b28cbd07a2ccdee05971651687cf3987ed2L82-R86) [[8]](diffhunk://#diff-d3a81c86206744cb98a81f1698c8fc2aba35f67e9c9a7d472b81aef725a6f13aL68-R72)

**Test Suite Updates**
* Removed `archive` dependency checks from all test files to reflect its removal from the codebase. [[1]](diffhunk://#diff-45660c1f5cd0dafcec30e6977ed7ef09695c841befd61c54ecceda8c9eb82b86L2) [[2]](diffhunk://#diff-0becc7ee1a1bb983888a63324215482581989a4fbf8e000566a982a5c4e8ebf9L2) [[3]](diffhunk://#diff-fc7580727a77564fd34a0c852761ff8876c485da8c08c001e8c72d5f6c17181bL29) [[4]](diffhunk://#diff-fc7580727a77564fd34a0c852761ff8876c485da8c08c001e8c72d5f6c17181bL52)