### PR TITLE
Fix community extension loading and temp file path bugs

### DIFF
--- a/R/tracts_to_h3.R
+++ b/R/tracts_to_h3.R
@@ -116,7 +116,8 @@ tracts_to_h3 <- function(
     )
 
     if (!ok) {
-      .duckdb_quiet_execute(con, sprintf("INSTALL %s;", ext))
+      # zipfs and h3 are community extensions
+      .duckdb_quiet_execute(con, sprintf("INSTALL %s FROM community;", ext))
       .duckdb_quiet_execute(con, sprintf("LOAD %s;", ext))
     }
     invisible(TRUE)

--- a/R/tracts_to_polygon.R
+++ b/R/tracts_to_polygon.R
@@ -159,7 +159,8 @@ cnefe_index <- .get_cnefe_index(year)
     )
 
     if (!ok) {
-      .duckdb_quiet_execute(con, sprintf("INSTALL %s;", ext))
+      # zipfs and h3 are community extensions
+      .duckdb_quiet_execute(con, sprintf("INSTALL %s FROM community;", ext))
       .duckdb_quiet_execute(con, sprintf("LOAD %s;", ext))
     }
     invisible(TRUE)

--- a/R/utils-internal.R
+++ b/R/utils-internal.R
@@ -223,7 +223,7 @@
   last_err <- NULL
 
   for (t in retry_timeouts) {
-    tmp <- fs::path_temp(ext = ".zip")
+    tmp <- tempfile(fileext = ".zip")
 
     if (isTRUE(verbose)) {
       message(
@@ -514,7 +514,7 @@
   last_err <- NULL
 
   for (t in retry_timeouts) {
-    tmp <- fs::path_temp()
+    tmp <- tempfile(fileext = ".parquet")
 
     if (isTRUE(verbose)) {
       message(
@@ -697,7 +697,7 @@
 ) {
   code_muni <- .normalize_code_muni(code_muni)
 
-  # Ensure zipfs is available
+  # Ensure zipfs is available (community extension)
   ok_zipfs <- tryCatch(
     {
       DBI::dbExecute(con, "LOAD zipfs;")
@@ -707,7 +707,7 @@
   )
 
   if (!ok_zipfs) {
-    DBI::dbExecute(con, "INSTALL zipfs;")
+    DBI::dbExecute(con, "INSTALL zipfs FROM community;")
     DBI::dbExecute(con, "LOAD zipfs;")
   }
 


### PR DESCRIPTION
## Summary
- Fix DuckDB community extension loading for `zipfs` and `h3` (closes #21)
- Fix temp file path bug in download functions (closes #23)

## Changes

### Issue #21 - Community extensions
DuckDB extensions `zipfs` and `h3` are community extensions and require `FROM community` in the install command:
- `tracts_to_h3.R`: Updated `.duckdb_load_ext()` to use `INSTALL %s FROM community;`
- `tracts_to_polygon.R`: Updated `.duckdb_load_ext()` to use `INSTALL %s FROM community;`
- `utils-internal.R`: Updated direct `INSTALL zipfs;` to `INSTALL zipfs FROM community;`

### Issue #23 - Temp file path
`fs::path_temp()` returns the temp **directory**, not a temp **file** path. Fixed by using `tempfile()`:
- `utils-internal.R:226`: `fs::path_temp(ext = ".zip")` → `tempfile(fileext = ".zip")`
- `utils-internal.R:517`: `fs::path_temp()` → `tempfile(fileext = ".parquet")`