### PR TITLE
add piggyback support and edit functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,4 +49,5 @@ Imports:
     cli (>= 3.6.0),
     checkmate,
     fs,
-    httr2
+    httr2,
+    piggyback


### PR DESCRIPTION
This pull request refactors the internal logic for downloading census tract parquet files and updates dependencies to improve asset management. The main changes involve switching from manual HTTP downloads to using the `piggyback` package for fetching release assets from GitHub, simplifying code and improving reliability.

**Dependency updates**

* Added the `piggyback` package to the `Imports` in `DESCRIPTION` to support downloading release assets from GitHub.

**Refactoring and feature improvements**

* Removed custom functions `.cnefetools_github_url`, `.sc_assets_download_base_url`, and `.sc_asset_url`, which previously constructed GitHub URLs manually for asset downloads. [[1]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L389-L417) [[2]](diffhunk://#diff-b73be4e3addecbf1ed9e4ca13f2f503b1705e9b81aa397e9247b28a15f804250L456-L466)
* Replaced the generic `.download_file_with_retry` function and related logic with `.sc_ensure_parquet_uf`, which now relies on the new `.sc_download_with_piggyback` helper to fetch files using the `piggyback` package. This change simplifies download logic, improves error handling, and better supports caching.
* Introduced `.sc_download_with_piggyback`, a new function that handles downloading files from GitHub releases using `piggyback`, including cache validation and error reporting.

Closes #22 