### PR TITLE
fix: skip tracts_to_h3 test on CRAN (DuckDB spatial segfault)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cnefetools
 Title: Access and Analysis of Brazilian CNEFE Address Data
-Version: 0.2.0
+Version: 0.2.1
 Authors@R:
     c(
       person(given = "Jorge Ubirajara", family = "Pedreira Junior",
@@ -45,7 +45,7 @@ Suggests:
 Config/testthat/edition: 3
 Depends: 
     R (>= 4.1.0)
-Imports: 
+Imports:
     arrow,
     dplyr,
     sf,

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,18 +1,20 @@
 ## Resubmission
 
-This is a resubmission addressing feedback from the CRAN reviewer:
+This patch release addresses the ERRORs flagged on CRAN check platforms:
 
-- Added IBGE FTP URL to the DESCRIPTION field.
-- Replaced `\dontrun{}` with `\donttest{}` in examples that download data,
-  and `@examplesIf interactive()` for viewer-only functions.
-- Cache directories are no longer created at package load time; directory
-  creation is deferred to the point a file is actually downloaded.
+- **Segfault on r-devel-linux-x86_64-fedora-clang**: The `tracts_to_h3` test
+  loaded the DuckDB spatial extension, which causes a C-level segfault
+  (signal 11) on this platform due to a known upstream ABI mismatch between
+  clang-compiled duckdb and GCC-built extension binaries
+  (duckdb/duckdb-r#1107, still open). This affects all packages that load
+  DuckDB extensions on Fedora-clang (e.g. duckspatial shows the same ERROR).
+  Since the crash cannot be caught by `tryCatch()`, the test now uses
+  `skip_on_cran()`.
 
-Additional fixes included in this version:
-
-- Fixed DuckDB spatial extension installation (core extension was incorrectly
-  fetched from the community repository).
-- Fixed allocation of `n_resp` and `avg_inc_resp` to private dwellings only.
+- **Missing `arrow` on r-oldrel-macos-x86_64**: This appears to be a
+  transient issue — `arrow` currently passes on that platform and other
+  packages with `arrow` in Imports (e.g. censobr) show OK. No changes were
+  made to the `arrow` dependency; resubmission should resolve this.
 
 ## R CMD check results
 

--- a/tests/testthat/test-test-tracts_to_h3.R
+++ b/tests/testthat/test-test-tracts_to_h3.R
@@ -1,4 +1,5 @@
 testthat::test_that("tracts_to_h3 returns an sf object with requested variables", {
+  testthat::skip_on_cran()
   testthat::skip_if_not_installed("duckdb")
   testthat::skip_if_not_installed("duckspatial")
   testthat::skip_if_not_installed("h3jsr")


### PR DESCRIPTION
## Summary

CRAN notified 2 ERRORs on [check platforms](https://cran.r-project.org/web/checks/check_results_cnefetools.html) with a deadline of 2026-02-26.

### ERROR 1: Segfault on `r-devel-linux-x86_64-fedora-clang`

The `tracts_to_h3` test loads the DuckDB spatial extension via `LOAD spatial;`, which causes a **C-level segfault (signal 11)** on this platform. The root cause is a known upstream Application Binary Interface (ABI) mismatch: DuckDB extension binaries are built with GNU Compiler Collection (GCC), but on CRAN's Fedora-clang builder the `duckdb` R package is compiled with clang. When the extension is dynamically loaded, the incompatibility crashes the R process before `tryCatch()` can intercept.

This is tracked in [duckdb/duckdb-r#1107](https://github.com/duckdb/duckdb-r/issues/1107) (open since April 2025, still unresolved as of duckdb v1.4.4). It affects **all** R packages that load DuckDB extensions — for example, [duckspatial has the same ERROR](https://cran.r-project.org/web/checks/check_results_duckspatial.html) on this exact platform right now.

The standard mitigation adopted by other packages is:
- **duckplyr** (tidyverse): pre-flight extension loadability checks + `skip_on_cran()` in tests ([tidyverse/duckplyr#620](https://github.com/tidyverse/duckplyr/issues/620), [tidyverse/duckplyr#636](https://github.com/tidyverse/duckplyr/issues/636))
- **duckspatial**: `skip_on_cran()` in tests + `@examplesIf interactive()` on functions that call `LOAD spatial` ([Cidree/duckspatial#1](https://github.com/Cidree/duckspatial/issues/1))

**Fix**: Add `testthat::skip_on_cran()` to the `tracts_to_h3` test. This is a heavyweight integration test requiring spatial, h3, and zipfs DuckDB extensions — it will continue running locally and on GitHub Actions.

### ERROR 2: Missing `arrow` on `r-oldrel-macos-x86_64`

The [check log](https://www.r-project.org/nosvn/R.check/r-oldrel-macos-x86_64/cnefetools-00check.html) reports `"Package required but not available: 'arrow'"`. However, this is a **transient** issue:

- [`arrow` itself currently shows **OK**](https://cran.r-project.org/web/checks/check_results_arrow.html) on `r-oldrel-macos-x86_64`
- [`censobr`](https://cran.r-project.org/web/checks/check_results_censobr.html) (which also has `arrow` in `Imports`) passes on all 14 CRAN flavors including this one
- [`duckspatial`](https://cran.r-project.org/web/checks/check_results_duckspatial.html) (which also has `arrow` in `Imports`) shows the **same ERROR** — both packages were likely checked during a window when arrow's binary was temporarily unavailable

**Fix**: No code changes needed. Resubmission should resolve this since `arrow` is available on that platform now.

### Changes

| File | Change |
|------|--------|
| `DESCRIPTION` | Version bump `0.2.0` → `0.2.1` |
| `tests/testthat/test-test-tracts_to_h3.R` | Add `skip_on_cran()` |
| `cran-comments.md` | Document both errors and their resolution |