### PR TITLE
fix: add cache=FALSE to donttest examples to resolve CRAN NOTE

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -14,3 +14,4 @@
 \.Rmd\.orig$
 _build\.R$
 ^CRAN-SUBMISSION$
+^paper$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cnefetools
 Title: Access and Analysis of Brazilian CNEFE Address Data
-Version: 0.2.3
+Version: 0.2.4
 Authors@R:
     c(
       person(given = "Jorge Ubirajara", family = "Pedreira Junior",

--- a/R/cnefe_counts.R
+++ b/R/cnefe_counts.R
@@ -52,7 +52,7 @@
 #' @examples
 #' \donttest{
 #' # Count addresses per H3 hexagon (resolution 9)
-#' hex_counts <- cnefe_counts(code_muni = 2929057)
+#' hex_counts <- cnefe_counts(code_muni = 2929057, cache = FALSE)
 #'
 #' # Count addresses per user-provided polygon (neighborhoods of Lauro de Freitas-BA)
 #' # Using geobr to download neighborhood boundaries
@@ -64,7 +64,8 @@
 #' hex_counts <- cnefe_counts(
 #'   code_muni = 2919207,
 #'   polygon_type = "user",
-#'   polygon = nei_ldf
+#'   polygon = nei_ldf,
+#'   cache = FALSE
 #' )
 #' }
 #'

--- a/R/compute_lumi.R
+++ b/R/compute_lumi.R
@@ -69,7 +69,7 @@
 #' @examples
 #' \donttest{
 #' # Compute land-use mix indices on H3 hexagons
-#' lumi <- compute_lumi(code_muni = 2929057)
+#' lumi <- compute_lumi(code_muni = 2929057, cache = FALSE)
 #'
 #' # Compute land-use mix indices on user-provided polygons (neighborhoods of Lauro de Freitas-BA)
 #' # Using geobr to download neighborhood boundaries
@@ -81,7 +81,8 @@
 #' lumi_poly <- compute_lumi(
 #'   code_muni = 2919207,
 #'   polygon_type = "user",
-#'   polygon = nei_ldf
+#'   polygon = nei_ldf,
+#'   cache = FALSE
 #' )
 #' }
 #'

--- a/R/read_cnefe.R
+++ b/R/read_cnefe.R
@@ -46,10 +46,10 @@
 #' @examples
 #' \donttest{
 #' # Read CNEFE data as an Arrow table
-#' cnefe <- read_cnefe(code_muni = 2929057)
+#' cnefe <- read_cnefe(code_muni = 2929057, cache = FALSE)
 #'
 #' # Read as an sf spatial object
-#' cnefe_sf <- read_cnefe(code_muni = 2929057, output = "sf")
+#' cnefe_sf <- read_cnefe(code_muni = 2929057, output = "sf", cache = FALSE)
 #' }
 #'
 #' @export

--- a/R/tracts_to_h3.R
+++ b/R/tracts_to_h3.R
@@ -47,7 +47,8 @@
 #' # Interpolate population to H3 hexagons
 #' hex_pop <- tracts_to_h3(
 #'   code_muni = 2929057,
-#'   vars = c("pop_ph", "pop_ch")
+#'   vars = c("pop_ph", "pop_ch"),
+#'   cache = FALSE
 #' )
 #' }
 #'

--- a/R/tracts_to_polygon.R
+++ b/R/tracts_to_polygon.R
@@ -62,7 +62,8 @@
 #' poly_pop <- tracts_to_polygon(
 #'   code_muni = 2919207,
 #'   polygon = nei_ldf,
-#'   vars = c("pop_ph", "pop_ch")
+#'   vars = c("pop_ph", "pop_ch"),
+#'   cache = FALSE
 #' )
 #' }
 #'

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,25 +1,20 @@
-## Submission (v0.2.3)
+## Resubmission (v0.2.4)
 
-This is a new release following the acceptance of v0.2.2 on CRAN.
+The package was archived on 2026-03-30 due to a NOTE flagged by the donttest
+checker: `\donttest{}` examples in five functions called package functions with
+`cache = TRUE` (the default), causing ZIP and Parquet files to be written to
+`~/.cache/R/cnefetools` during the check run.
 
-### Changes in this version
+### Fix
 
-* `cnefe_counts()` and `compute_lumi()` now expose a `cache` parameter
-  (default `TRUE`), consistent with `tracts_to_h3()` and `tracts_to_polygon()`.
-* New `clear_cache_muni()` and `clear_cache_tracts()` functions to delete
-  cached files from the user cache directory.
-* Fixed missing hexagons at municipality boundaries in `build_h3_grid()`:
-  `h3jsr::polygon_to_cells()` only returns hexagons whose centroid falls
-  inside the boundary; border hexagons are now recovered via a k=1 neighbour
-  ring filtered by `sf::st_intersects()`.
+Added `cache = FALSE` to all function calls inside `\donttest{}` blocks in:
+`read_cnefe()`, `cnefe_counts()`, `compute_lumi()`, `tracts_to_h3()`, and
+`tracts_to_polygon()`. Examples now use temporary files and leave no persistent
+files on the check machine.
 
 ## R CMD check results
 
-0 errors | 0 warnings | 1 note
-
-* `NOTE: unable to verify current time` — this is a transient CRAN
-  infrastructure issue (the check server cannot reach time-verification
-  servers) and is unrelated to the package code.
+0 errors | 0 warnings | 0 notes
 
 ## Test environments
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -14,7 +14,15 @@ files on the check machine.
 
 ## R CMD check results
 
-0 errors | 0 warnings | 0 notes
+0 errors | 0 warnings | 2 notes
+
+* `NOTE: unable to verify current time` — transient CRAN infrastructure
+  issue (check server cannot reach time-verification servers); unrelated
+  to the package.
+* `NOTE: Non-standard file/directory found at top level: 'paper'` — the
+  `paper/` directory (R Journal manuscript) lives on disk during local
+  checks because it is maintained on a separate git branch. It is listed
+  in `.Rbuildignore` and is not included in the built tarball.
 
 ## Test environments
 


### PR DESCRIPTION
## Summary

- CRAN archived the package on 2026-03-30 because the donttest checker found persistent files in `~/.cache/R/cnefetools`
- Five functions had `\donttest{}` examples calling with `cache = TRUE` (default), writing ZIPs and Parquet files to the user cache dir
- Added `cache = FALSE` to all affected example calls in `read_cnefe()`, `cnefe_counts()`, `compute_lumi()`, `tracts_to_h3()`, and `tracts_to_polygon()`
- Updated `cran-comments.md` for v0.2.4 resubmission

Closes #66

## Test plan

- [ ] `devtools::check()` locally shows 0 errors | 0 warnings | 0 notes
- [ ] Verify no files are created in `~/.cache/R/cnefetools` after running examples with `--run-donttest`