### PR TITLE
fix: resolve RTREE index and ZIP cleanup errors for CRAN resubmission (v0.2.5)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cnefetools
 Title: Access and Analysis of Brazilian CNEFE Address Data
-Version: 0.2.4
+Version: 0.2.5
 Authors@R:
     c(
       person(given = "Jorge Ubirajara", family = "Pedreira Junior",

--- a/R/cnefe_counts.R
+++ b/R/cnefe_counts.R
@@ -660,6 +660,14 @@ g., 4674, 31983) or a CRS object."
     )
   )
 
+  # duckspatial 1.0.0 (DuckDB 1.5+) writes GEOMETRY with embedded CRS metadata
+  # (e.g. GEOMETRY('OGC:CRS84')), which DuckDB's RTREE index does not accept.
+  # A WKB round-trip strips the CRS parameter and yields plain GEOMETRY.
+  DBI::dbExecute(con,
+    "ALTER TABLE user_polygons ALTER COLUMN geom SET DATA TYPE GEOMETRY
+     USING ST_GeomFromWKB(ST_AsWKB(geom));"
+  )
+
   # Spatial index on user polygons for faster joins
   DBI::dbExecute(
     con,

--- a/R/compute_lumi.R
+++ b/R/compute_lumi.R
@@ -794,6 +794,14 @@ compute_lumi <- function(
     overwrite = TRUE
   )
 
+  # duckspatial 1.0.0 (DuckDB 1.5+) writes GEOMETRY with embedded CRS metadata,
+  # which RTREE does not accept. Strip CRS via WKB round-trip first.
+  DBI::dbExecute(
+    con,
+    "ALTER TABLE user_polygons ALTER COLUMN geom SET DATA TYPE GEOMETRY
+     USING ST_GeomFromWKB(ST_AsWKB(geom));"
+  )
+
   # Spatial index on user polygons for faster joins
   DBI::dbExecute(
     con,

--- a/R/tracts_to_h3.R
+++ b/R/tracts_to_h3.R
@@ -227,16 +227,21 @@ tracts_to_h3 <- function(
 
   }
 
+  # Create lazy views (cnefe_raw, cnefe_pts) that read from the ZIP file.
+  # The ZIP must remain on disk until the views are materialised into a table.
+  zip_info_cnefe <- suppressMessages(
+    .cnefe_create_points_view_in_duckdb(
+      con,
+      code_muni = code_muni,
+      index = cnefe_index,
+      cache = cache,
+      verbose = verbose
+    )
+  )
+
+  # Materialise the lazy view into a table (reads ZIP data into DuckDB memory).
   invisible(utils::capture.output({
     invisible(utils::capture.output({
-      .cnefe_create_points_view_in_duckdb(
-        con,
-        code_muni = code_muni,
-        index = cnefe_index,
-        cache = cache,
-        verbose = verbose
-      )
-
       .duckdb_quiet_execute(
         con,
         "
@@ -256,6 +261,11 @@ tracts_to_h3 <- function(
       )$n[1]
     }, type = "message"))
   }, type = "output"))
+
+  # ZIP data is now fully in DuckDB — safe to delete the temp file.
+  if (is.list(zip_info_cnefe) && isTRUE(zip_info_cnefe$cleanup_zip)) {
+    on.exit(unlink(zip_info_cnefe$zip_path), add = TRUE)
+  }
 
   if (verbose) {
     cli::cli_progress_done("Step 3/6: preparing CNEFE points in DuckDB...")

--- a/R/tracts_to_polygon.R
+++ b/R/tracts_to_polygon.R
@@ -358,7 +358,8 @@ cnefe_index <- .get_cnefe_index(year)
 
   }
 
-  .cnefe_create_points_view_in_duckdb(
+  # Create lazy views (cnefe_raw, cnefe_pts) that read from the ZIP file.
+  zip_info_cnefe <- .cnefe_create_points_view_in_duckdb(
     con,
     code_muni = code_muni,
     index = cnefe_index,
@@ -366,6 +367,7 @@ cnefe_index <- .get_cnefe_index(year)
     verbose = verbose
   )
 
+  # Materialise the lazy view (reads ZIP data into DuckDB memory).
   .duckdb_quiet_execute(
     con,
     "
@@ -383,6 +385,11 @@ cnefe_index <- .get_cnefe_index(year)
     con,
     "SELECT COUNT(*) AS n FROM cnefe_pts_tbl;"
   )$n[1]
+
+  # ZIP data is now fully in DuckDB — safe to delete the temp file.
+  if (is.list(zip_info_cnefe) && isTRUE(zip_info_cnefe$cleanup_zip)) {
+    on.exit(unlink(zip_info_cnefe$zip_path), add = TRUE)
+  }
 
   if (verbose) {
     cli::cli_progress_done("Step 4/6: preparing CNEFE points in DuckDB...")
@@ -581,6 +588,14 @@ cnefe_index <- .get_cnefe_index(year)
       ),
       type = "output"
     )
+  )
+
+  # duckspatial 1.0.0 (DuckDB 1.5+) writes GEOMETRY with embedded CRS metadata,
+  # which RTREE does not accept. Strip CRS via WKB round-trip first.
+  .duckdb_quiet_execute(
+    con,
+    "ALTER TABLE user_polygons ALTER COLUMN geom SET DATA TYPE GEOMETRY
+     USING ST_GeomFromWKB(ST_AsWKB(geom));"
   )
 
   # Create spatial index on user polygons

--- a/R/utils-internal.R
+++ b/R/utils-internal.R
@@ -797,10 +797,9 @@
     )
   })
 
-  # Clean up temp ZIP if cache = FALSE
-  if (isTRUE(zip_info$cleanup_zip)) {
-    on.exit(unlink(zip_path), add = TRUE)
-  }
-
-  invisible(TRUE)
+  # Return zip_info so callers can manage cleanup after materialising the views.
+  # Do NOT register on.exit here: cnefe_pts is a lazy VIEW that reads from the
+  # ZIP file; if the ZIP were deleted on function exit, any subsequent
+  # CREATE TABLE ... AS SELECT * FROM cnefe_pts in the caller would fail.
+  invisible(zip_info)
 }

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,28 +1,63 @@
-## Resubmission (v0.2.4)
+## Resubmission (v0.2.5)
 
-The package was archived on 2026-03-30 due to a NOTE flagged by the donttest
-checker: `\donttest{}` examples in five functions called package functions with
-`cache = TRUE` (the default), causing ZIP and Parquet files to be written to
-`~/.cache/R/cnefetools` during the check run.
+### Previous submission (v0.2.4) rejection
 
-### Fix
+v0.2.4 failed the CRAN incoming pre-test (donttest checker, 2026-03-30) with
+an ERROR in `cnefe_counts()`:
 
-Added `cache = FALSE` to all function calls inside `\donttest{}` blocks in:
-`read_cnefe()`, `cnefe_counts()`, `compute_lumi()`, `tracts_to_h3()`, and
-`tracts_to_polygon()`. Examples now use temporary files and leave no persistent
-files on the check machine.
+```
+Binder Error: RTree indexes can only be created over GEOMETRY columns.
+```
+
+### Root cause
+
+Two packages released between the local check and the CRAN check introduced a
+breaking change:
+
+* **DuckDB 1.5.0** (2026-03-09): moved the `GEOMETRY` type from the spatial
+  extension into DuckDB core.  The new core `GEOMETRY` type supports optional
+  CRS parameters (e.g. `GEOMETRY('OGC:CRS84')`).
+* **duckspatial 1.0.0** (2026-03-30): rewritten for DuckDB 1.5; now writes
+  geometry columns with embedded CRS metadata (i.e. as a parameterised
+  `GEOMETRY` type).
+
+DuckDB's RTREE index only accepts *plain* `GEOMETRY` (no CRS parameter).
+The CRS-parameterised column produced by duckspatial 1.0.0 therefore caused
+the binder error.
+
+### Fix 1 — RTREE index (DuckDB 1.5 + duckspatial 1.0.0)
+
+Before creating the RTREE index on tables written by `duckspatial::ddbs_write_vector()`,
+a WKB round-trip is now performed to strip the CRS parameter and convert the
+column to plain `GEOMETRY`:
+
+```sql
+ALTER TABLE user_polygons ALTER COLUMN geom SET DATA TYPE GEOMETRY
+USING ST_GeomFromWKB(ST_AsWKB(geom));
+```
+
+Applied in: `cnefe_counts()`, `tracts_to_polygon()`, and `compute_lumi()`.
+
+### Fix 2 — temporary ZIP deleted before DuckDB view materialisation
+
+The helper `.cnefe_create_points_view_in_duckdb()` creates lazy DuckDB views
+that read from a ZIP file.  When `cache = FALSE` (added in v0.2.4), an
+`on.exit(unlink(zip_path))` registered inside the helper deleted the ZIP as
+soon as the helper returned, before the caller had a chance to materialise the
+view into a table (`CREATE TABLE ... AS SELECT * FROM cnefe_pts`).  This
+caused `tracts_to_h3()` and `tracts_to_polygon()` to error at the CNEFE point
+preparation step.
+
+The cleanup responsibility was moved to each caller: the temp ZIP is now
+deleted only after the view has been fully materialised into a DuckDB table.
 
 ## R CMD check results
 
-0 errors | 0 warnings | 2 notes
+0 errors | 0 warnings | 1 note
 
 * `NOTE: unable to verify current time` — transient CRAN infrastructure
   issue (check server cannot reach time-verification servers); unrelated
   to the package.
-* `NOTE: Non-standard file/directory found at top level: 'paper'` — the
-  `paper/` directory (R Journal manuscript) lives on disk during local
-  checks because it is maintained on a separate git branch. It is listed
-  in `.Rbuildignore` and is not included in the built tarball.
 
 ## Test environments
 

--- a/man/cnefe_counts.Rd
+++ b/man/cnefe_counts.Rd
@@ -82,7 +82,7 @@ The counts in the columns \code{addr_type1} to \code{addr_type8} correspond to:
 \examples{
 \donttest{
 # Count addresses per H3 hexagon (resolution 9)
-hex_counts <- cnefe_counts(code_muni = 2929057)
+hex_counts <- cnefe_counts(code_muni = 2929057, cache = FALSE)
 
 # Count addresses per user-provided polygon (neighborhoods of Lauro de Freitas-BA)
 # Using geobr to download neighborhood boundaries
@@ -94,7 +94,8 @@ nei_ldf <- subset(
 hex_counts <- cnefe_counts(
   code_muni = 2919207,
   polygon_type = "user",
-  polygon = nei_ldf
+  polygon = nei_ldf,
+  cache = FALSE
 )
 }
 

--- a/man/compute_lumi.Rd
+++ b/man/compute_lumi.Rd
@@ -81,7 +81,7 @@ Pedreira Jr. et al. (2025).
 \examples{
 \donttest{
 # Compute land-use mix indices on H3 hexagons
-lumi <- compute_lumi(code_muni = 2929057)
+lumi <- compute_lumi(code_muni = 2929057, cache = FALSE)
 
 # Compute land-use mix indices on user-provided polygons (neighborhoods of Lauro de Freitas-BA)
 # Using geobr to download neighborhood boundaries
@@ -93,7 +93,8 @@ nei_ldf <- subset(
 lumi_poly <- compute_lumi(
   code_muni = 2919207,
   polygon_type = "user",
-  polygon = nei_ldf
+  polygon = nei_ldf,
+  cache = FALSE
 )
 }
 

--- a/man/read_cnefe.Rd
+++ b/man/read_cnefe.Rd
@@ -64,10 +64,10 @@ removed when the function exits.
 \examples{
 \donttest{
 # Read CNEFE data as an Arrow table
-cnefe <- read_cnefe(code_muni = 2929057)
+cnefe <- read_cnefe(code_muni = 2929057, cache = FALSE)
 
 # Read as an sf spatial object
-cnefe_sf <- read_cnefe(code_muni = 2929057, output = "sf")
+cnefe_sf <- read_cnefe(code_muni = 2929057, output = "sf", cache = FALSE)
 }
 
 }

--- a/man/tracts_to_h3.Rd
+++ b/man/tracts_to_h3.Rd
@@ -72,7 +72,8 @@ The function uses DuckDB with the spatial and H3 extensions for the heavy work.
 # Interpolate population to H3 hexagons
 hex_pop <- tracts_to_h3(
   code_muni = 2929057,
-  vars = c("pop_ph", "pop_ch")
+  vars = c("pop_ph", "pop_ch"),
+  cache = FALSE
 )
 }
 

--- a/man/tracts_to_polygon.Rd
+++ b/man/tracts_to_polygon.Rd
@@ -89,7 +89,8 @@ nei_ldf <- subset(
 poly_pop <- tracts_to_polygon(
   code_muni = 2919207,
   polygon = nei_ldf,
-  vars = c("pop_ph", "pop_ch")
+  vars = c("pop_ph", "pop_ch"),
+  cache = FALSE
 )
 }
 


### PR DESCRIPTION
Two bugs broke donttest examples after DuckDB 1.5.0 + duckspatial 1.0.0:

1. RTREE index creation failed with "RTree indexes can only be created over
   GEOMETRY columns". duckspatial 1.0.0 now writes CRS-parameterised GEOMETRY
   columns; DuckDB 1.5 RTREE requires plain GEOMETRY. Fix: perform a WKB
   round-trip (ST_GeomFromWKB(ST_AsWKB(geom))) before CREATE INDEX in
   cnefe_counts, tracts_to_polygon, and compute_lumi.

2. Temp ZIP deleted before DuckDB view materialisation. With cache=FALSE,
   .cnefe_create_points_view_in_duckdb() registered on.exit(unlink(zip))
   inside the helper, deleting the ZIP before the caller could run
   CREATE TABLE ... AS SELECT * FROM cnefe_pts. Fix: move cleanup to
   the caller, after the view is fully materialised.

Closes #68
