### PR TITLE
fix: normalize polygon geometry column to "geom" for DuckDB writes (#70)

### DIFF
--- a/R/cnefe_counts.R
+++ b/R/cnefe_counts.R
@@ -651,7 +651,9 @@ g., 4674, 31983) or a CRS object."
       suppressMessages(
         duckspatial::ddbs_write_vector(
           conn = con,
-          data = polygon[, ".poly_row_id"],
+          # Normalize geometry column to "geom"; duckspatial preserves the
+          # input sf geometry name, but the SQL below hardcodes "geom".
+          data = sf::st_set_geometry(polygon[, ".poly_row_id"], "geom"),
           name = "user_polygons",
           overwrite = TRUE
         )

--- a/R/compute_lumi.R
+++ b/R/compute_lumi.R
@@ -789,7 +789,9 @@ compute_lumi <- function(
   # Write user polygon to DuckDB via duckspatial
   duckspatial::ddbs_write_vector(
     conn = con,
-    data = polygon[, ".poly_row_id"],
+    # Normalize geometry column to "geom"; duckspatial preserves the
+    # input sf geometry name, but the SQL below hardcodes "geom".
+    data = sf::st_set_geometry(polygon[, ".poly_row_id"], "geom"),
     name = "user_polygons",
     overwrite = TRUE
   )

--- a/R/tracts_to_polygon.R
+++ b/R/tracts_to_polygon.R
@@ -581,7 +581,9 @@ cnefe_index <- .get_cnefe_index(year)
       suppressMessages(
         duckspatial::ddbs_write_vector(
           conn = con,
-          data = polygon_4326[, ".poly_row_id"],
+          # Normalize geometry column to "geom"; duckspatial preserves the
+          # input sf geometry name, but the SQL below hardcodes "geom".
+          data = sf::st_set_geometry(polygon_4326[, ".poly_row_id"], "geom"),
           name = "user_polygons",
           overwrite = TRUE
         )

--- a/tests/testthat/test-cnefe_counts.R
+++ b/tests/testthat/test-cnefe_counts.R
@@ -183,6 +183,98 @@ testthat::test_that("cnefe_counts works with user polygon (backend r, polygon_ty
 })
 
 
+testthat::test_that("cnefe_counts (duckdb) handles polygon with 'geometry' column (#70)", {
+  testthat::skip_on_cran()
+  testthat::skip_if_not_installed("arrow")
+  testthat::skip_if_not_installed("dplyr")
+  testthat::skip_if_not_installed("duckdb")
+  testthat::skip_if_not_installed("duckspatial")
+  testthat::skip_if_not_installed("sf")
+
+  # Skip if DuckDB cannot load/install the required extensions
+  con_check <- DBI::dbConnect(duckdb::duckdb(), dbdir = ":memory:")
+  on.exit(DBI::dbDisconnect(con_check, shutdown = TRUE), add = TRUE)
+
+  ext_ok <- function(name) {
+    tryCatch(
+      {
+        DBI::dbExecute(con_check, sprintf("LOAD %s;", name))
+        TRUE
+      },
+      error = function(e) {
+        tryCatch(
+          {
+            DBI::dbExecute(con_check, sprintf("INSTALL %s; LOAD %s;", name, name))
+            TRUE
+          },
+          error = function(e2) FALSE
+        )
+      }
+    )
+  }
+
+  if (!ext_ok("zipfs")) testthat::skip("DuckDB zipfs extension not available.")
+  if (!ext_ok("spatial")) testthat::skip("DuckDB spatial extension not available.")
+
+  code_muni <- 2929057L
+
+  tab <- testthat::with_mocked_bindings(
+    cnefetools::read_cnefe(
+      code_muni,
+      verbose = FALSE,
+      cache = TRUE,
+      output = "arrow"
+    ),
+    .cnefe_ensure_zip = mock_ensure_zip_fixture,
+    .package = "cnefetools"
+  )
+
+  df <- as.data.frame(tab) |>
+    dplyr::transmute(
+      LONGITUDE = suppressWarnings(as.numeric(.data$LONGITUDE)),
+      LATITUDE = suppressWarnings(as.numeric(.data$LATITUDE)),
+      COD_ESPECIE = suppressWarnings(as.integer(.data$COD_ESPECIE))
+    ) |>
+    dplyr::filter(
+      !is.na(.data$LONGITUDE),
+      !is.na(.data$LATITUDE),
+      !is.na(.data$COD_ESPECIE),
+      .data$COD_ESPECIE %in% 1L:8L
+    )
+
+  # Bounding-box polygon with the sf default geometry column name "geometry"
+  bbox <- sf::st_bbox(
+    sf::st_as_sf(df, coords = c("LONGITUDE", "LATITUDE"), crs = 4326)
+  )
+  test_polygon <- sf::st_sf(id = 1L, geometry = sf::st_as_sfc(bbox))
+  testthat::expect_identical(attr(test_polygon, "sf_column"), "geometry")
+
+  # Before the #70 fix this errored with:
+  # Binder Error: Table "user_polygons" does not have a column with name "geom"
+  out <- testthat::with_mocked_bindings(
+    suppressWarnings(
+      cnefetools::cnefe_counts(
+        code_muni,
+        polygon_type = "user",
+        polygon = test_polygon,
+        backend = "duckdb",
+        verbose = FALSE
+      )
+    ),
+    .cnefe_ensure_zip = mock_ensure_zip_fixture,
+    .package = "cnefetools"
+  )
+
+  testthat::expect_s3_class(out, "sf")
+  testthat::expect_equal(nrow(out), 1L)
+
+  # All points fall inside the bbox, so totals must match the raw data
+  cols <- paste0("addr_type", 1:8)
+  actual_total <- sum(vapply(cols, function(cc) sum(out[[cc]]), numeric(1)))
+  testthat::expect_equal(actual_total, nrow(df))
+})
+
+
 testthat::test_that("cnefe_counts validates polygon argument", {
   testthat::skip_if_not_installed("sf")
 


### PR DESCRIPTION
## Summary

Fixes the R-CMD-check failure on `main` (broken by the `duckspatial` 1.1.0 release, not by any package code change).

`duckspatial` (>= 1.1.0) changed `ddbs_write_vector()` to **preserve** the input `sf` geometry column name, whereas 1.0.0 renamed it to `"geom"`. The DuckDB backend SQL hardcodes `"geom"` in the `ALTER TABLE`, `RTREE` index, and `ST_Within` join statements, so any polygon with the sf default geometry name `"geometry"` now crashes with:

```
Binder Error: Table "user_polygons" does not have a column with name "geom"
```

## Fix

Normalize the geometry column to `"geom"` via `sf::st_set_geometry()` immediately before each `ddbs_write_vector()` call, in the three affected functions:

- `R/cnefe_counts.R`
- `R/compute_lumi.R`
- `R/tracts_to_polygon.R`

This is robust to both `duckspatial` 1.0.0 and 1.1.0, and is idempotent when the column is already named `"geom"`.

> Note: the issue suggested `sf::rename_geometry()`, but that helper is not exported by `sf`. `sf::st_set_geometry(x, "geom")` is the public API that renames the geometry column, verified locally.

## Test

Adds a regression test in `tests/testthat/test-cnefe_counts.R` that exercises the **DuckDB backend** with a polygon whose geometry column is named `"geometry"` (the sf default). It is guarded with `skip_on_cran()` and DuckDB extension-availability checks, consistent with the existing DuckDB test. Verified failing before the fix and passing after.

Closes #70
