### PR TITLE
fix: make cnefetools robust to geobr 2.0.0 duckdb temp-table collision (#74)

### DIFF
--- a/R/utils-internal.R
+++ b/R/utils-internal.R
@@ -382,7 +382,31 @@
     args$keep_areas_operacionais <- FALSE
   }
 
-  # 4. Safe execution with error handling
+  # 4. Isolate the RNG state around the geobr call.
+  # geobr (>= 2.0.0) reads boundaries lazily through duckspatial, and dbplyr
+  # derives its temporary table name from sample(), i.e. from the global RNG
+  # state. Under a fixed seed (e.g. R CMD check examples) repeated calls would
+  # generate the same name and collide on a reused DuckDB connection with
+  # "Table dbplyr_<...> already exists". Reseed from entropy so each call gets
+  # a unique name, then restore the caller's RNG state so we do not disturb
+  # their reproducibility.
+  if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+    old_seed <- get(".Random.seed", envir = .GlobalEnv, inherits = FALSE)
+    on.exit(
+      assign(".Random.seed", old_seed, envir = .GlobalEnv),
+      add = TRUE
+    )
+  } else {
+    on.exit(
+      if (exists(".Random.seed", envir = .GlobalEnv, inherits = FALSE)) {
+        rm(".Random.seed", envir = .GlobalEnv)
+      },
+      add = TRUE
+    )
+  }
+  set.seed(NULL)
+
+  # 5. Safe execution with error handling
   muni <- tryCatch(
     {
       suppressMessages(
@@ -402,7 +426,7 @@
     }
   )
 
-  # 5. Output Validation
+  # 6. Output Validation
   # Ensure we actually got a valid sf object back
   if (!inherits(muni, "sf") || nrow(muni) == 0L) {
     cli::cli_abort(c(


### PR DESCRIPTION
## Summary

Makes cnefetools work with **any geobr version** (including geobr 2.0.0) instead of pinning the dependency.

geobr 2.0.0 (CRAN, 2026-05-20) reads boundaries lazily via duckspatial. Under R CMD check `--run-donttest`, repeated geobr calls in the same session (`cnefe_counts`, then `compute_lumi`) hit a dbplyr/duckdb temporary-table name collision:

```
! Catalog Error: Table with name "dbplyr_4dMaH8wQnr" already exists!
```

`dbplyr::unique_table_name()` derives the name from `sample()`, so under the deterministic RNG used by R CMD check examples the name repeats and collides on a reused DuckDB connection.

## Fix

In `.read_muni_boundary_2024()`, isolate the RNG state around the `geobr::read_municipality()` call: save the caller's `.Random.seed`, `set.seed(NULL)` to reseed from entropy (unique temp-table name per call), and restore the caller's seed on exit. Harmless on geobr 1.9.x, fixes the collision on 2.0.0, and does not disturb user reproducibility.

Validated locally (geobr 1.9.x):
- `set.seed(NULL)` yields unique `dbplyr_*` names even in rapid succession and under a fixed outer seed.
- The caller's RNG stream is byte-identical before/after the call.
- `.read_muni_boundary_2024()` still returns a valid `sf` object.

> Note: geobr 2.0.0 cannot be exercised on the maintainer's machine (separate machine-local `check_con` error, see #72), so the geobr-2.0.0 path is validated by CI, which installs geobr 2.0.0 from RSPM.

## ⚠️ Stacked on #73 — review/merge order

This PR is **stacked on top of #73** (the #70 `"geom"` column fix). Both fixes are required together for a green R CMD check:

- #73 alone fails on the geobr 2.0.0 collision.
- This fix alone (from `main`) would fail earlier on the #70 `"geom"` error.

By stacking, this branch contains both fixes, so its CI exercises the full `--run-donttest` run end to end with geobr 2.0.0.

**Recommended:** merge #73 first, then rebase this branch onto `main` (GitHub drops the #73 commit from the diff automatically) and merge.

## Follow-up

- Report the `dbplyr_*** already exists` collision upstream to geobr / duckspatial (via #72, @rafapereirabr).

Closes #74
